### PR TITLE
store에서 내부에서 작성되던 dispatch를 제거 & 분리

### DIFF
--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -2,4 +2,51 @@ import 'core-js';
 import './scss/app.scss';
 import './scss/app.css';
 import { qs } from './utils';
-const app = qs('#app');
+import core from './core';
+import store from './store';
+const app = qs('#app') as HTMLElement;
+
+class Year extends core.PureComponent {
+  setup() {
+    this.$state = {
+      year: store.subscribe('year', this),
+    };
+  }
+  template() {
+    return `
+      <h1>${this.$state.year}</h1>
+    `;
+  }
+}
+
+class Month extends core.RootComponent {
+  setup() {
+    this.$state = {
+      month: store.subscribe('month', this),
+    };
+  }
+
+  template() {
+    return `
+    <div>
+      ${this.$state.month}
+      <button class="plus-btn">+</button>
+      <button class="minus-btn">-</button>
+    </div>
+    `;
+  }
+  setEvent() {
+    this.addEvent('click', '.plus-btn', e =>
+      store.commit({ type: 'setMonth', stateName: 'month', value: this.$state.month + 1 })
+    );
+    this.addEvent('click', '.minus-btn', e =>
+      store.commit({ type: 'setMonth', stateName: 'month', value: this.$state.month - 1 })
+    );
+  }
+}
+const $year = document.createElement('div');
+new Year($year, {});
+const $month = document.createElement('div');
+new Month($month, '', {});
+
+app.append($year, $month);

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -52,6 +52,9 @@ export function createStore<T extends IRootState>(initialState: T, mutations: IM
 
   function commit(payload: ICommit<keyof T>): void {
     const { type, stateName, value } = payload;
+    if (mutations[type] === undefined) {
+      throw new Error(`${type}에 해당하는 mutation이 없습니다.`);
+    }
     const mutatedValue = mutations[type]({ state, value, commit });
     setState(stateName, mutatedValue);
   }

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -1,0 +1,64 @@
+export interface ISubscriber {
+  setState: (state: any) => void;
+}
+
+export interface IRootState {
+  [key: string]: {
+    value: any;
+    subs: ISubscriber[];
+  };
+}
+
+interface ICommit<T> {
+  type: string;
+  stateName: T;
+  value: any;
+}
+
+interface IMutationPayload<T> {
+  state: T;
+  value: any;
+  commit: (payload: ICommit<keyof T>) => void;
+}
+
+export interface IMutation<T> {
+  [key: string]: (payload: IMutationPayload<T>) => any;
+}
+
+export function createStore<T extends IRootState>(initialState: T, mutations: IMutation<T>) {
+  type StateName = keyof T;
+
+  const state: T = initialState;
+
+  function getState(stateName: StateName): any {
+    return state[stateName].value;
+  }
+
+  function subscribe(stateName: StateName, subscriber: ISubscriber): any {
+    state[stateName].subs.push(subscriber);
+    return state[stateName].value;
+  }
+
+  function setState(stateName: StateName, value: any): void {
+    state[stateName].value = value;
+    const nextState: T = {
+      ...state,
+      [stateName]: value,
+    };
+    state[stateName].subs.forEach((subscriber: ISubscriber) => {
+      subscriber.setState(nextState);
+    });
+  }
+
+  function commit(payload: ICommit<keyof T>): void {
+    const { type, stateName, value } = payload;
+    const mutatedValue = mutations[type]({ state, value, commit });
+    setState(stateName, mutatedValue);
+  }
+
+  return {
+    getState,
+    subscribe,
+    commit,
+  };
+}

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,89 +1,32 @@
-export interface ISubscriber {
-  setState: (state: any) => void;
+import { createStore } from '../lib/store';
+import mutations from './mutations';
+import { IRootState, ISubscriber } from '../lib/store';
+
+export interface state extends IRootState {
+  year: {
+    value: number;
+    subs: ISubscriber[];
+  };
+  month: {
+    value: number;
+    subs: ISubscriber[];
+  };
 }
 
-function Store() {
-  type stateType = {
-    isLogin: { value: boolean; subs: ISubscriber[] };
-    year: { value: number; subs: ISubscriber[] };
-    month: { value: number; subs: ISubscriber[] };
-    datas: { value: any; subs: ISubscriber[] };
-  };
-
-  type StateName = keyof stateType;
-
-  const state: stateType = {
-    isLogin: {
-      value: false,
-      subs: [],
-    },
+const store = createStore<state>(
+  {
     year: {
       value: new Date().getFullYear(),
-      subs: [],
+      subs: [] as ISubscriber[],
     },
     month: {
       value: new Date().getMonth() + 1,
-      subs: [],
+      subs: [] as ISubscriber[],
     },
-    datas: {
-      value: {},
-      subs: [],
-    },
-  };
-
-  function getState(stateName: StateName): any {
-    return state[stateName].value;
+  },
+  {
+    ...mutations,
   }
-
-  function subscribe(stateName: StateName, subscriber: ISubscriber): any {
-    state[stateName].subs.push(subscriber);
-    return state[stateName].value;
-  }
-
-  function setState(stateName: StateName, value: any): void {
-    state[stateName].value = value;
-    const nextState: { [key: string]: any } = {};
-    nextState[stateName] = value;
-    state[stateName].subs.forEach((subscriber: ISubscriber) => {
-      subscriber.setState(nextState);
-    });
-  }
-
-  function dateChangeHandler(nextRawMonth: number) {
-    let nextMonth: number = nextRawMonth;
-    if (nextMonth < 1 || nextMonth > 12) {
-      let nextYear = state.year.value;
-      if (nextMonth < 1) {
-        nextMonth = 12;
-        nextYear -= 1;
-      } else {
-        nextMonth = 1;
-        nextYear += 1;
-      }
-      setState('year', nextYear);
-    }
-    setState('month', nextMonth);
-    // 비동기 요청으로 날짜에 맞는 데이터 요청하기
-  }
-
-  const dispatch = {
-    monthLeftClick() {
-      const nextRawMonth = state.month.value - 1;
-      dateChangeHandler(nextRawMonth);
-    },
-    monthRightClick() {
-      const nextRawMonth = state.month.value + 1;
-      dateChangeHandler(nextRawMonth);
-    },
-  };
-
-  return {
-    getState,
-    subscribe,
-    dispatch,
-  };
-}
-
-const store = Store();
+);
 
 export default store;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,10 +1,17 @@
+export interface ISubscriber {
+  setState: (state: any) => void;
+}
+
 function Store() {
   type stateType = {
-    isLogin: { value: boolean; subs: Array<any> };
-    year: { value: number; subs: Array<any> };
-    month: { value: number; subs: Array<any> };
-    datas: { value: object; subs: Array<any> };
+    isLogin: { value: boolean; subs: ISubscriber[] };
+    year: { value: number; subs: ISubscriber[] };
+    month: { value: number; subs: ISubscriber[] };
+    datas: { value: any; subs: ISubscriber[] };
   };
+
+  type StateName = keyof stateType;
+
   const state: stateType = {
     isLogin: {
       value: false,
@@ -23,21 +30,25 @@ function Store() {
       subs: [],
     },
   };
-  function getState(stateName: string): any {
-    return eval(`state.${stateName}`).value;
+
+  function getState(stateName: StateName): any {
+    return state[stateName].value;
   }
-  function subscribe(stateName: string, subscriber: any): any {
-    eval(`state.${stateName}`).subs.push(subscriber);
-    return eval(`state.${stateName}`).value;
+
+  function subscribe(stateName: StateName, subscriber: ISubscriber): any {
+    state[stateName].subs.push(subscriber);
+    return state[stateName].value;
   }
-  function setState(stateName: string, value: any): void {
-    eval(`state.${stateName}`).value = value;
+
+  function setState(stateName: StateName, value: any): void {
+    state[stateName].value = value;
     const nextState: { [key: string]: any } = {};
     nextState[stateName] = value;
-    eval(`state.${stateName}`).subs.forEach((subscriber: any) => {
+    state[stateName].subs.forEach((subscriber: ISubscriber) => {
       subscriber.setState(nextState);
     });
   }
+
   function dateChangeHandler(nextRawMonth: number) {
     let nextMonth: number = nextRawMonth;
     if (nextMonth < 1 || nextMonth > 12) {
@@ -54,6 +65,7 @@ function Store() {
     setState('month', nextMonth);
     // 비동기 요청으로 날짜에 맞는 데이터 요청하기
   }
+
   const dispatch = {
     monthLeftClick() {
       const nextRawMonth = state.month.value - 1;
@@ -64,6 +76,7 @@ function Store() {
       dateChangeHandler(nextRawMonth);
     },
   };
+
   return {
     getState,
     subscribe,

--- a/client/src/store/mutations.ts
+++ b/client/src/store/mutations.ts
@@ -1,0 +1,25 @@
+import { IMutation } from '../lib/store';
+import { state } from './index';
+
+const mutations: IMutation<state> = {
+  setYear: ({ value }) => {
+    return value;
+  },
+  setMonth: ({ state, value, commit }) => {
+    let nextMonth: number = value;
+    if (nextMonth < 1 || nextMonth > 12) {
+      let nextYear = state.year.value;
+      if (nextMonth < 1) {
+        nextMonth = 12;
+        nextYear -= 1;
+      } else {
+        nextMonth = 1;
+        nextYear += 1;
+      }
+      commit({ type: 'setYear', stateName: 'year', value: nextYear });
+    }
+    return nextMonth;
+  },
+};
+
+export default mutations;


### PR DESCRIPTION
- store 내부에서 작동되던 dispatch를 store 함수에서 제거 했습니다.
- store 함수를 createStore로 이름을 바꾸고, initialState와 mutations을 받는 방식으로 바꿨습니다.

- mutations는 dispatch와 비슷한 역할을 합니다.(vuex를 참고해서 구현)

### 논의해야할 사항

- 비동기 처리에 대해서도 따로 구현을 해도 되지만, 현재 상태에서는 필요한지 아닌지 잘 모르겠어서 논의가 필요합니다..
- mutations으로 하면 store 내부에서 dispatch 부분을 따로 빼서 작성할 수 있지만, 간단한 상태 바꾸기에 필요한 코드가 불필요하게 많아보이기도 합니다.
- 기존코드
```ts
function dateChangeHandler(nextRawMonth: number) {
    let nextMonth: number = nextRawMonth;
    if (nextMonth < 1 || nextMonth > 12) {
      let nextYear = state.year.value;
      if (nextMonth < 1) {
        nextMonth = 12;
        nextYear -= 1;
      } else {
        nextMonth = 1;
        nextYear += 1;
      }
      setState('year', nextYear);
    }
    setState('month', nextMonth);
    // 비동기 요청으로 날짜에 맞는 데이터 요청하기
  }

  const dispatch = {
    monthLeftClick() {
      const nextRawMonth = state.month.value - 1;
      dateChangeHandler(nextRawMonth);
    },
    monthRightClick() {
      const nextRawMonth = state.month.value + 1;
      dateChangeHandler(nextRawMonth);
    },
  };
```

- mutations을 적용한 코드(setYear 같은 코드가 생김)
```ts
const mutations: IMutation<state> = {
  setYear: ({ value }) => {
    return value;
  },
  setMonth: ({ state, value, commit }) => {
    let nextMonth: number = value;
    if (nextMonth < 1 || nextMonth > 12) {
      let nextYear = state.year.value;
      if (nextMonth < 1) {
        nextMonth = 12;
        nextYear -= 1;
      } else {
        nextMonth = 1;
        nextYear += 1;
      }
      commit({ type: 'setYear', stateName: 'year', value: nextYear });
    }
    return nextMonth;
  },
};
```