### PR TITLE
기간에 따른 history 불러오기 api, history 생성 api 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,6 +29,7 @@ app.use(function (req, res, next) {
 // error handler
 app.use(function (err, req, res, next) {
   // set locals, only providing error in development
+  console.error(err);
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 

--- a/server/models/CardCategory.js
+++ b/server/models/CardCategory.js
@@ -15,6 +15,7 @@ module.exports = function (sequelize, DataTypes) {
   cardCategory.associate = function (models) {
     cardCategory.hasMany(models['Card'], {
       foreignKey: {
+        name: 'cardCategoryId',
         allowNull: false,
       },
       onDelete: 'CASCADE',

--- a/server/models/Cards.js
+++ b/server/models/Cards.js
@@ -15,6 +15,7 @@ module.exports = function (sequelize, DataTypes) {
   card.associate = function (models) {
     card.belongsTo(models['User'], {
       foreignKey: {
+        name: 'userId',
         allowNull: false,
       },
       as: 'user',
@@ -22,6 +23,7 @@ module.exports = function (sequelize, DataTypes) {
     });
     card.belongsTo(models['CardCategory'], {
       foreignKey: {
+        name: 'cardCategoryId',
         allowNull: false,
       },
       as: 'cardCategory',
@@ -29,6 +31,7 @@ module.exports = function (sequelize, DataTypes) {
     });
     card.hasMany(models['History'], {
       foreignKey: {
+        name: 'cardId',
         allowNull: false,
       },
       onDelete: 'CASCADE',

--- a/server/models/History.js
+++ b/server/models/History.js
@@ -1,3 +1,5 @@
+const Sequelize = require('sequelize');
+
 module.exports = function (sequelize, DataTypes) {
   const history = sequelize.define(
     'History',
@@ -10,9 +12,9 @@ module.exports = function (sequelize, DataTypes) {
         type: DataTypes.INTEGER,
         allowNull: false,
       },
-      created_at: {
+      createdAt: {
         type: DataTypes.DATEONLY,
-        defaultValue: DataTypes.NOW,
+        defaultValue: Sequelize.literal(`(CURRENT_DATE)`),
         allowNull: false,
       },
     },

--- a/server/models/History.js
+++ b/server/models/History.js
@@ -26,6 +26,7 @@ module.exports = function (sequelize, DataTypes) {
   history.associate = function (models) {
     history.belongsTo(models['Card'], {
       foreignKey: {
+        name: 'cardId',
         allowNull: false,
       },
       as: 'card',
@@ -33,6 +34,7 @@ module.exports = function (sequelize, DataTypes) {
     });
     history.belongsTo(models['User'], {
       foreignKey: {
+        name: 'userId',
         allowNull: false,
       },
       as: 'user',
@@ -40,6 +42,7 @@ module.exports = function (sequelize, DataTypes) {
     });
     history.belongsTo(models['Type'], {
       foreignKey: {
+        name: 'typeId',
         allowNull: false,
       },
       as: 'type',

--- a/server/models/Type.js
+++ b/server/models/Type.js
@@ -15,6 +15,7 @@ module.exports = function (sequelize, DataTypes) {
   type.associate = function (models) {
     type.hasMany(models['History'], {
       foreignKey: {
+        name: 'typeId',
         allowNull: false,
       },
       onDelete: 'CASCADE',

--- a/server/models/Users.js
+++ b/server/models/Users.js
@@ -19,12 +19,14 @@ module.exports = function (sequelize, DataTypes) {
   user.associate = function (models) {
     user.hasMany(models['Card'], {
       foreignKey: {
+        name: 'userId',
         allowNull: false,
       },
       onDelete: 'CASCADE',
     });
     user.hasMany(models['History'], {
       foreignKey: {
+        name: 'userId',
         allowNull: false,
       },
       onDelete: 'CASCADE',

--- a/server/routes/history.js
+++ b/server/routes/history.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+const historyService = require('../services/history');
+const { privateRouter } = require('../middlewares/auth');
+const { validDate } = require('../utils/date');
+
+router.get('/api/v1/history', privateRouter, async (req, res, next) => {
+  const { user } = req;
+  const { year, month } = req.query;
+
+  if (!year) {
+    res.status(400).json({});
+    return;
+  }
+
+  if (month && !validDate(year, month)) {
+    res.status(400).json({});
+    return;
+  }
+
+  try {
+    const histories = await historyService.findAllHistoryByDate({ userId: user.id, year, month });
+    res.status(200).json({ histories });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/history.js
+++ b/server/routes/history.js
@@ -29,14 +29,14 @@ router.get('/api/v1/history', privateRouter, async (req, res, next) => {
 router.post('/api/v1/history', privateRouter, async (req, res, next) => {
   try {
     const { user } = req;
-    const { content, cardId, typeId, price } = req.body;
+    const { content, cardId, typeId, price, createdAt } = req.body;
 
     if (!(content && cardId && typeId && price)) {
       res.status(400).json({});
       return;
     }
 
-    const history = await historyService.createHistory({ userId: user.id, cardId, content, price, typeId });
+    const history = await historyService.createHistory({ userId: user.id, cardId, content, price, typeId, createdAt });
 
     res.status(201).json({ history });
   } catch (err) {

--- a/server/routes/history.js
+++ b/server/routes/history.js
@@ -37,6 +37,7 @@ router.post('/api/v1/history', privateRouter, async (req, res, next) => {
     }
 
     const history = await historyService.createHistory({ userId: user.id, cardId, content, price, typeId });
+
     res.status(201).json({ history });
   } catch (err) {
     next(err);

--- a/server/routes/history.js
+++ b/server/routes/history.js
@@ -26,4 +26,21 @@ router.get('/api/v1/history', privateRouter, async (req, res, next) => {
   }
 });
 
+router.post('/api/v1/history', privateRouter, async (req, res, next) => {
+  try {
+    const { user } = req;
+    const { content, cardId, typeId, price } = req.body;
+
+    if (!(content && cardId && typeId && price)) {
+      res.status(400).json({});
+      return;
+    }
+
+    const history = await historyService.createHistory({ userId: user.id, cardId, content, price, typeId });
+    res.status(201).json({ history });
+  } catch (err) {
+    next(err);
+  }
+});
+
 module.exports = router;

--- a/server/routes/history.js
+++ b/server/routes/history.js
@@ -20,7 +20,7 @@ router.get('/api/v1/history', privateRouter, async (req, res, next) => {
 
   try {
     const histories = await historyService.findAllHistoryByDate({ userId: user.id, year, month });
-    res.status(200).json({ histories });
+    res.status(200).json({ ...histories });
   } catch (err) {
     next(err);
   }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,11 +4,13 @@ const userRouter = require('./user');
 const categoryRouter = require('./category');
 const historyRouter = require('./history');
 const categoryRouter = require('./category');
+const historyRouter = require('./history');
 
 /* GET home page. */
 router.use(userRouter);
 router.use(categoryRouter);
 router.use(historyRouter);
 router.use(categoryRouter);
+router.use(historyRouter);
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,7 +10,5 @@ const historyRouter = require('./history');
 router.use(userRouter);
 router.use(categoryRouter);
 router.use(historyRouter);
-router.use(categoryRouter);
-router.use(historyRouter);
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,10 +3,12 @@ const router = express.Router();
 const userRouter = require('./user');
 const categoryRouter = require('./category');
 const historyRouter = require('./history');
+const categoryRouter = require('./category');
 
 /* GET home page. */
 router.use(userRouter);
 router.use(categoryRouter);
 router.use(historyRouter);
+router.use(categoryRouter);
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const userRouter = require('./user');
 const categoryRouter = require('./category');
+const historyRouter = require('./history');
 
 /* GET home page. */
 router.use(userRouter);
 router.use(categoryRouter);
+router.use(historyRouter);
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,8 +3,6 @@ const router = express.Router();
 const userRouter = require('./user');
 const categoryRouter = require('./category');
 const historyRouter = require('./history');
-const categoryRouter = require('./category');
-const historyRouter = require('./history');
 
 /* GET home page. */
 router.use(userRouter);

--- a/server/services/card.js
+++ b/server/services/card.js
@@ -4,7 +4,7 @@ const findAllByUserId = async userId => {
   const cards = await Card.findAll({
     attributes: ['id', 'name'],
     where: {
-      UserId: userId,
+      userId,
     },
     include: ['cardCategory'],
   });

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -1,0 +1,26 @@
+const History = require('../models')['History'];
+const { Op } = require('sequelize');
+const { getDateRange } = require('../utils/date');
+
+const findAllHistoryByDate = async ({ userId, year, month }) => {
+  const [startDate, endDate] = getDateRange(year, month);
+
+  const histories = await History.findAll({
+    where: {
+      [Op.and]: [
+        { userId },
+        {
+          created_At: {
+            [Op.between]: [startDate, endDate],
+          },
+        },
+      ],
+    },
+  });
+
+  return histories;
+};
+
+module.exports = {
+  findAllHistoryByDate,
+};

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -31,15 +31,29 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
 };
 
 const createHistory = async ({ userId, cardId, content, price, typeId }) => {
-  const history = await History.create({
-    userId,
-    cardId,
-    content,
-    price,
-    typeId,
+  const history = await History.create(
+    {
+      userId,
+      cardId,
+      content,
+      price,
+      typeId,
+    },
+    {
+      include: ['type', 'user', 'card'],
+    }
+  );
+  const finded = await History.findOne({
+    attributes: ['id', 'content', 'price', 'createdAt'],
+    where: { id: history.id },
+    include: [
+      { model: Type, as: 'type' },
+      { model: User, as: 'user' },
+      { model: Card, as: 'card', attributes: ['id', 'name'], include: ['cardCategory'] },
+    ],
   });
 
-  return history;
+  return finded;
 };
 
 module.exports = {

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -30,7 +30,7 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
   return histories;
 };
 
-const createHistory = async ({ userId, cardId, content, price, typeId }) => {
+const createHistory = async ({ userId, cardId, content, price, typeId, createdAt }) => {
   const history = await History.create(
     {
       userId,
@@ -38,6 +38,7 @@ const createHistory = async ({ userId, cardId, content, price, typeId }) => {
       content,
       price,
       typeId,
+      createdAt,
     },
     {
       include: ['type', 'user', 'card'],

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -3,16 +3,16 @@ const Type = require('../models')['Type'];
 const Card = require('../models')['Card'];
 const User = require('../models')['User'];
 const { Op } = require('sequelize');
-const { getDateRange, createDayObj, createMonthObj } = require('../utils/date');
+const { getDateRange, makeDayObj, makeMonthObj } = require('../utils/date');
 
-const createHistoryPerDay = (year, month, histories) => {
-  const dayObj = createDayObj(year, month);
+const groupingHistoryPerDay = (year, month, histories) => {
+  const dayObj = makeDayObj(year, month);
   histories.forEach(history => dayObj[history.createdAt].push(history));
   return dayObj;
 };
 
-const createHistoryPerMonth = (year, histories) => {
-  let monthObj = createMonthObj(year);
+const groupingHistoryPerMonth = (year, histories) => {
+  let monthObj = makeMonthObj(year);
   monthObj = histories.reduce((acc, val) => {
     const { price, createdAt } = val;
     const [year, month] = createdAt.split('-');
@@ -46,10 +46,10 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
   });
 
   if (month) {
-    const historiesPerDay = createHistoryPerDay(year, month, histories);
+    const historiesPerDay = groupingHistoryPerDay(year, month, histories);
     return historiesPerDay;
   } else {
-    const historiesPerMonth = createHistoryPerMonth(year, histories);
+    const historiesPerMonth = groupingHistoryPerMonth(year, histories);
     return historiesPerMonth;
   }
 };

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -21,6 +21,19 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
   return histories;
 };
 
+const createHistory = async ({ userId, cardId, content, price, typeId }) => {
+  const history = await History.create({
+    userId,
+    cardId,
+    content,
+    price,
+    typeId,
+  });
+
+  return history;
+};
+
 module.exports = {
   findAllHistoryByDate,
+  createHistory,
 };

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -1,4 +1,7 @@
 const History = require('../models')['History'];
+const Type = require('../models')['Type'];
+const Card = require('../models')['Card'];
+const User = require('../models')['User'];
 const { Op } = require('sequelize');
 const { getDateRange } = require('../utils/date');
 
@@ -6,6 +9,7 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
   const [startDate, endDate] = getDateRange(year, month);
 
   const histories = await History.findAll({
+    attributes: ['id', 'content', 'price', 'createdAt'],
     where: {
       [Op.and]: [
         { userId },
@@ -16,6 +20,11 @@ const findAllHistoryByDate = async ({ userId, year, month }) => {
         },
       ],
     },
+    include: [
+      { model: Type, as: 'type' },
+      { model: User, as: 'user' },
+      { model: Card, as: 'card', attributes: ['id', 'name'], include: ['cardCategory'] },
+    ],
   });
 
   return histories;

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -14,11 +14,14 @@ const getYearMonth = (year, month) => {
 };
 
 const getDateRange = (year, month) => {
-  const startDate = new Date(`${year}-${month}-2`);
-  const endDate = new Date(`${getYearMonth(year, month)}-1`);
+  if (month) {
+    const startDate = new Date(`${year}-${month}-2`);
+    const endDate = new Date(`${getYearMonth(year, month)}-1`);
+    return [startDate, endDate];
+  }
 
-  console.log(startDate);
-  console.log(endDate);
+  const startDate = new Date(`${year}-1-2`);
+  const endDate = new Date(`${+year + 1}-1-1`);
 
   return [startDate, endDate];
 };

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -1,5 +1,53 @@
 const validDate = (year, month) => month >= 1 && month <= 12 && year >= 1900;
 
+const isLeapYear = year => {
+  if (year % 4 === 0 && year % 100 === 0 && year % 400 === 0) return true;
+  if (year % 4 === 0 && year % 100 === 0) return false;
+  if (year % 4 === 0) return true;
+  return false;
+};
+
+const dayOfMonth = (month, isLeap = false) => {
+  switch (+month) {
+    case 1:
+    case 3:
+    case 5:
+    case 7:
+    case 8:
+    case 10:
+    case 12:
+      return 31;
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      return 30;
+    case 2:
+      if (isLeap) {
+        return 29;
+      }
+      return 28;
+  }
+};
+
+const createDayObj = (year, month) => {
+  const day = dayOfMonth(month, isLeapYear(year));
+  const dayObj = {};
+  for (let i = 1; i <= day; i++) {
+    dayObj[`${year}-${month.padStart(2, '0')}-${i.toString().padStart(2, '0')}`] = [];
+  }
+  return dayObj;
+};
+
+const createMonthObj = year => {
+  const month = 12;
+  const monthObj = {};
+  for (let i = 1; i <= month; i++) {
+    monthObj[`${year}-${i.toString().padStart(2, '0')}`] = { expediture: [], income: [] };
+  }
+  return monthObj;
+};
+
 const getYearMonth = (year, month) => {
   year = +year;
   month = +month;
@@ -15,12 +63,12 @@ const getYearMonth = (year, month) => {
 
 const getDateRange = (year, month) => {
   if (month) {
-    const startDate = new Date(`${year}-${month}-2`);
+    const startDate = new Date(`${year}-${month}-1`);
     const endDate = new Date(`${getYearMonth(year, month)}-1`);
     return [startDate, endDate];
   }
 
-  const startDate = new Date(`${year}-1-2`);
+  const startDate = new Date(`${year}-1-1`);
   const endDate = new Date(`${+year + 1}-1-1`);
 
   return [startDate, endDate];
@@ -29,4 +77,6 @@ const getDateRange = (year, month) => {
 module.exports = {
   validDate,
   getDateRange,
+  createDayObj,
+  createMonthObj,
 };

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -1,0 +1,29 @@
+const validDate = (year, month) => month >= 1 && month <= 12 && year >= 1900;
+
+const getYearMonth = (year, month) => {
+  year = +year;
+  month = +month;
+
+  if (month + 1 === 13) {
+    ++year;
+    month = 1;
+  } else {
+    ++month;
+  }
+  return `${year}-${month}`;
+};
+
+const getDateRange = (year, month) => {
+  const startDate = new Date(`${year}-${month}-2`);
+  const endDate = new Date(`${getYearMonth(year, month)}-1`);
+
+  console.log(startDate);
+  console.log(endDate);
+
+  return [startDate, endDate];
+};
+
+module.exports = {
+  validDate,
+  getDateRange,
+};

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -30,7 +30,7 @@ const dayOfMonth = (month, isLeap = false) => {
   }
 };
 
-const createDayObj = (year, month) => {
+const makeDayObj = (year, month) => {
   const day = dayOfMonth(month, isLeapYear(year));
   const dayObj = {};
   for (let i = 1; i <= day; i++) {
@@ -39,7 +39,7 @@ const createDayObj = (year, month) => {
   return dayObj;
 };
 
-const createMonthObj = year => {
+const makeMonthObj = year => {
   const month = 12;
   const monthObj = {};
   for (let i = 1; i <= month; i++) {
@@ -77,6 +77,6 @@ const getDateRange = (year, month) => {
 module.exports = {
   validDate,
   getDateRange,
-  createDayObj,
-  createMonthObj,
+  makeDayObj,
+  makeMonthObj,
 };


### PR DESCRIPTION
- 에러 메세지를 보기 위해서 app.js 기본 error 핸들러에 console.error를 추가했음.
- 기간을 구하기 위해서 date util 추가
- findAllHistoryByDate 함수 구현
   - user, 기간에 해당하는 history를 불러와서 반환 
- historyService createHistory 구현

### 버그 fix
- History created_at defaultValue가 작동하지 않았음
   - Date 타입인 경우에는 sequelize.literal('(CURRENT_DATE)') 사용
   - Datetime 인 경우에는 sequelize.literal('CURRENT_TIMESTAMP') 사용
- model을 정의할 때 foreignkey를 직접 명시해주지 않았는데, 이렇게 되면 중복 컬럼이 발생되어 버그가 발생했음
   - 모든 model의 association 부분에 foreignkey를 명시해주는 것으로 해결 [참고](https://github.com/sequelize/sequelize/issues/3035)

### 해결 못한 부분

- create 하고 난 다음 바로 include 해서 가져오고 싶었는데, 해당 부분이 잘 안가져와져서 우선 fineOne을 한번 더 실행,
   - created_at 또한 값이 생성이 안된 객체가 반환됨

### 추가 구현 부분
- history를 불러오는 과정에서 월별, 일별 데이터로 가져올 수 있게 추가구현 하였습니다.
